### PR TITLE
feat: add AI-based action scorer

### DIFF
--- a/types/index.ts
+++ b/types/index.ts
@@ -25,4 +25,5 @@ export interface PlayerStats {
 export interface AIResponse {
   category: string;
   score: number;
+  taskQuality: "good" | "lazy";
 }


### PR DESCRIPTION
## Summary
- replace mock scoring with OpenAI-powered evaluator that assigns category, score, and task quality
- extend `AIResponse` type to include `taskQuality`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b3f74b401083329cdf6132c397f8c2