### PR TITLE
feat: add action feedback and quality

### DIFF
--- a/components/ActionLog.tsx
+++ b/components/ActionLog.tsx
@@ -24,7 +24,9 @@ export function ActionLog({ actions }: ActionLogProps) {
         {actions.map((action) => (
           <div
             key={action.id}
-            className="flex items-center justify-between p-3 bg-gray-50 rounded-lg border-l-4 border-blue-400"
+            className={`flex items-center justify-between p-3 bg-gray-50 rounded-lg border-l-4 ${
+              action.taskQuality === 'good' ? 'border-green-400' : 'border-red-400'
+            }`}
           >
             <div className="flex-1">
               <p className="font-medium text-gray-800 mb-1">{action.text}</p>
@@ -32,11 +34,29 @@ export function ActionLog({ actions }: ActionLogProps) {
                 <span className="bg-blue-100 text-blue-800 px-2 py-1 rounded-full text-xs font-medium">
                   {action.category}
                 </span>
+                <span
+                  className={`px-2 py-1 rounded-full text-xs font-medium ${
+                    action.taskQuality === 'good'
+                      ? 'bg-green-100 text-green-800'
+                      : 'bg-red-100 text-red-800'
+                  }`}
+                >
+                  {action.taskQuality === 'good' ? 'Good' : 'Lazy'}
+                </span>
                 <div className="flex items-center gap-1">
                   <Clock className="w-3 h-3" />
                   <span>{action.timestamp.toLocaleDateString()}</span>
                 </div>
               </div>
+              {action.feedback && (
+                <p
+                  className={`mt-1 text-sm ${
+                    action.taskQuality === 'good' ? 'text-green-700' : 'text-red-700'
+                  }`}
+                >
+                  {action.feedback}
+                </p>
+              )}
             </div>
             <div className="text-right">
               <div className="flex items-center gap-1 text-yellow-600 font-bold">

--- a/components/ActionLogger.tsx
+++ b/components/ActionLogger.tsx
@@ -24,12 +24,14 @@ export function ActionLogger({ onActionLogged }: ActionLoggerProps) {
     try {
       const aiResponse = await scoreAction(actionText);
       const xp = Math.floor(aiResponse.score / 10);
-      
+
       const action: Action = {
         id: Date.now().toString(),
         text: actionText,
         category: aiResponse.category,
         score: aiResponse.score,
+        taskQuality: aiResponse.taskQuality,
+        feedback: aiResponse.feedback,
         xp,
         timestamp: new Date(),
       };

--- a/lib/ai-scorer.ts
+++ b/lib/ai-scorer.ts
@@ -61,19 +61,20 @@ export const scoreAction = async (actionText: string): Promise<AIResponse> => {
         throw new Error("OPENAI_API_KEY is not set");
     }
 
-    const systemPrompt = `You are a ruthless but fair life coach inside a gamified productivity system. 
-   Your job is to judge the user's actions like they are logging moves in a real-life RPG. 
+    const systemPrompt = `You are a ruthless but fair life coach inside a gamified productivity system.
+    Your job is to judge the user's actions like they are logging moves in a real-life RPG.
 
-   - Categorize the task into one of: ${CATEGORIES.join(", ")}. 
-   - Score the task 0-100 (higher = more valuable to long-term growth). 
-   - Label it as "good" if it meaningfully pushes the player forward, 
-     or "lazy" if it's entertainment, procrastination, or meaningless filler. 
-   - Be strict. Do NOT inflate scores to be nice. If they did something weak, punish them. 
-   - Treat obviously lazy actions (gaming, scrolling, junk food, oversleeping, etc.) with contempt. 
-   - Treat serious work (deep focus, building, outreach, training) as heroic. 
+    - Categorize the task into one of: ${CATEGORIES.join(", ")}.
+    - Score the task 0-100 (higher = more valuable to long-term growth).
+    - Label it as "good" if it meaningfully pushes the player forward,
+      or "lazy" if it's entertainment, procrastination, or meaningless filler.
+    - Provide a short, no-nonsense feedback message.
+    - Be strict. Do NOT inflate scores to be nice. If they did something weak, punish them.
+    - Treat obviously lazy actions (gaming, scrolling, junk food, oversleeping, etc.) with contempt.
+    - Treat serious work (deep focus, building, outreach, training) as heroic.
 
-   Respond ONLY in raw JSON, no extra text. Keys: 
-   { "score": number, "category": string, "taskQuality": "good" | "lazy" }`;
+    Respond ONLY in raw JSON, no extra text. Keys:
+    { "score": number, "category": string, "taskQuality": "good" | "lazy", "feedback": string }`;
 
     const response = await fetch("https://api.openai.com/v1/chat/completions", {
         method: "POST",
@@ -113,6 +114,7 @@ export const scoreAction = async (actionText: string): Promise<AIResponse> => {
         typeof parsed.category === "string" ? parsed.category : "General";
     const score = typeof parsed.score === "number" ? parsed.score : 50;
     const taskQuality = parsed.taskQuality === "good" ? "good" : "lazy";
+    const feedback = typeof parsed.feedback === "string" ? parsed.feedback : "";
 
-    return { category, score, taskQuality };
+    return { category, score, taskQuality, feedback };
 };

--- a/types/index.ts
+++ b/types/index.ts
@@ -3,6 +3,8 @@ export interface Action {
   text: string;
   category: string;
   score: number;
+  taskQuality: "good" | "lazy";
+  feedback: string;
   xp: number;
   timestamp: Date;
 }
@@ -26,4 +28,5 @@ export interface AIResponse {
   category: string;
   score: number;
   taskQuality: "good" | "lazy";
+  feedback: string;
 }


### PR DESCRIPTION
## Summary
- extend `Action` and `AIResponse` with `taskQuality` and `feedback`
- request qualitative feedback from AI scorer and parse response
- log and display task quality feedback in action log

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Inter` font from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68b3fc113f6883328629a44dd4f4a635