### PR TITLE
Refactor XP progression to piecewise model and add tests

### DIFF
--- a/__tests__/xp-system.test.js
+++ b/__tests__/xp-system.test.js
@@ -1,0 +1,24 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { xpForLevel, calculateLevel, xpToNextLevel } = require('../build/xp-system.js');
+
+test('xpForLevel thresholds', () => {
+  assert.strictEqual(xpForLevel(1), 0);
+  assert.strictEqual(xpForLevel(9), 312);
+  assert.strictEqual(xpForLevel(10), 362);
+  assert.strictEqual(xpForLevel(50), 5362);
+});
+
+test('calculateLevel boundaries', () => {
+  assert.strictEqual(calculateLevel(0), 1);
+  assert.strictEqual(calculateLevel(xpForLevel(9)), 9);
+  assert.strictEqual(calculateLevel(xpForLevel(10) - 1), 9);
+  assert.strictEqual(calculateLevel(xpForLevel(10)), 10);
+  assert.strictEqual(calculateLevel(xpForLevel(50)), 50);
+});
+
+test('xpToNextLevel at boundaries', () => {
+  assert.strictEqual(xpToNextLevel(xpForLevel(1)), xpForLevel(2) - xpForLevel(1));
+  assert.strictEqual(xpToNextLevel(xpForLevel(9)), xpForLevel(10) - xpForLevel(9));
+  assert.strictEqual(xpToNextLevel(xpForLevel(10)), xpForLevel(11) - xpForLevel(10));
+});

--- a/lib/xp-system.ts
+++ b/lib/xp-system.ts
@@ -1,12 +1,50 @@
-import { Category, PlayerStats, Action } from '@/types';
+import { Category, PlayerStats, Action } from '../types';
 
-// Total XP required to reach the start of a given level (quadratic progression)
+// XP required to reach the start of each level up to level 10.
+// These values keep early levels quick (≈3-5 tasks per level).
+const EARLY_LEVEL_THRESHOLDS: number[] = [
+  0,   // Level 1
+  30,  // Level 2
+  63,  // Level 3
+  98,  // Level 4
+  136, // Level 5
+  176, // Level 6
+  219, // Level 7
+  264, // Level 8
+  312, // Level 9
+  362, // Level 10
+];
+
+// Constant XP gained per level after level 10 (~10-15 tasks)
+const POST_10_INCREMENT = 125;
+
+// Total XP required to reach the start of a given level (piecewise progression)
 export const xpForLevel = (level: number): number => {
-  return 100 * (level - 1) * (level - 1);
+  if (level <= EARLY_LEVEL_THRESHOLDS.length) {
+    return EARLY_LEVEL_THRESHOLDS[level - 1];
+  }
+
+  const base = EARLY_LEVEL_THRESHOLDS[EARLY_LEVEL_THRESHOLDS.length - 1];
+  return base + (level - EARLY_LEVEL_THRESHOLDS.length) * POST_10_INCREMENT;
 };
 
+// Determine level from total XP using the piecewise thresholds
 export const calculateLevel = (xp: number): number => {
-  return Math.floor(Math.sqrt(xp / 100)) + 1;
+  // Handle early levels using the table
+  for (let i = EARLY_LEVEL_THRESHOLDS.length - 1; i >= 0; i--) {
+    const threshold = EARLY_LEVEL_THRESHOLDS[i];
+    if (xp >= threshold) {
+      if (i === EARLY_LEVEL_THRESHOLDS.length - 1) {
+        // We're in the constant-increment region
+        return (
+          EARLY_LEVEL_THRESHOLDS.length +
+          Math.floor((xp - threshold) / POST_10_INCREMENT)
+        );
+      }
+      return i + 1;
+    }
+  }
+  return 1;
 };
 
 export const getXPForCurrentLevel = (xp: number): number => {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "tsc lib/xp-system.ts --outDir build --module commonjs --target es2018 --lib es2018,dom --esModuleInterop --skipLibCheck && node --test __tests__/xp-system.test.js"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",


### PR DESCRIPTION
## Summary
- replace quadratic XP curve with table-driven levels 1-10 and constant increment afterwards
- update level calculations to use new thresholds
- add unit tests covering XP and level boundaries

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4040c80148332a765096d148ee446